### PR TITLE
Migrate to Documenter v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Documentation theme for the packages of JuliaDynamics
 
-*(requires at least documenter `v0.24.6`)*
+*(requires at least Documenter `v1.0`)*
 
 This repo provides a unified style for Documenter.jl documentation build of the packages of JuliaDynamics, and also provides a simplified way to apply it on a repo.
 

--- a/apply_style.jl
+++ b/apply_style.jl
@@ -3,10 +3,16 @@ CI = get(ENV, "CI", nothing) == "true" || get(ENV, "GITHUB_TOKEN", nothing) !== 
 using Documenter
 using DocumenterTools: Themes
 ENV["JULIA_DEBUG"] = "Documenter"
+
+# For easier debugging when downloading from a specific branch.
+github_user = "JuliaDynamics"
+branch = "master"
+download_path = "https://raw.githubusercontent.com/$github_user/doctheme/$branch"
+
 # download the themes
 import Downloads
 for file in ("juliadynamics-lightdefs.scss", "juliadynamics-darkdefs.scss", "juliadynamics-style.scss")
-    Downloads.download("https://raw.githubusercontent.com/kahaaga/doctheme/master/$file", joinpath(@__DIR__, file))
+    Downloads.download("$download_path/$file", joinpath(@__DIR__, file))
 end
 # create the themes
 for w in ("light", "dark")
@@ -19,5 +25,5 @@ Themes.compile(joinpath(@__DIR__, "juliadynamics-light.scss"), joinpath(@__DIR__
 Themes.compile(joinpath(@__DIR__, "juliadynamics-dark.scss"), joinpath(@__DIR__, "src/assets/themes/documenter-dark.css"))
 # Download and apply CairoMakie plotting style
 using CairoMakie
-Downloads.download("https://raw.githubusercontent.com/kahaaga/doctheme/master/style.jl", joinpath(@__DIR__, "style.jl"))
+Downloads.download("$download_path/style.jl", joinpath(@__DIR__, "style.jl"))
 include("style.jl")

--- a/apply_style.jl
+++ b/apply_style.jl
@@ -6,7 +6,7 @@ ENV["JULIA_DEBUG"] = "Documenter"
 # download the themes
 import Downloads
 for file in ("juliadynamics-lightdefs.scss", "juliadynamics-darkdefs.scss", "juliadynamics-style.scss")
-    Downloads.download("https://raw.githubusercontent.com/JuliaDynamics/doctheme/master/$file", joinpath(@__DIR__, file))
+    Downloads.download("https://raw.githubusercontent.com/kahaaga/doctheme/master/$file", joinpath(@__DIR__, file))
 end
 # create the themes
 for w in ("light", "dark")
@@ -19,5 +19,5 @@ Themes.compile(joinpath(@__DIR__, "juliadynamics-light.scss"), joinpath(@__DIR__
 Themes.compile(joinpath(@__DIR__, "juliadynamics-dark.scss"), joinpath(@__DIR__, "src/assets/themes/documenter-dark.css"))
 # Download and apply CairoMakie plotting style
 using CairoMakie
-Downloads.download("https://raw.githubusercontent.com/JuliaDynamics/doctheme/master/style.jl", joinpath(@__DIR__, "style.jl"))
+Downloads.download("https://raw.githubusercontent.com/kahaaga/doctheme/master/style.jl", joinpath(@__DIR__, "style.jl"))
 include("style.jl")

--- a/build_docs_with_style.jl
+++ b/build_docs_with_style.jl
@@ -54,7 +54,7 @@ function build_docs_with_style(pages, modules...; bib = nothing, authors = "Geor
     if isnothing(bib)
         makedocs(; settings...)
     else
-        makedocs(bib; settings...)
+        makedocs(; plugins=[bib], settings...)
     end
 
     if CI

--- a/build_docs_with_style.jl
+++ b/build_docs_with_style.jl
@@ -1,7 +1,7 @@
 CI = get(ENV, "CI", nothing) == "true" || get(ENV, "GITHUB_TOKEN", nothing) !== nothing
 
 import Pkg
-Pkg.pkg"add Documenter@0.27"
+Pkg.pkg"add Documenter@1.2"
 
 # Load documenter
 using Documenter

--- a/build_docs_with_style.jl
+++ b/build_docs_with_style.jl
@@ -9,12 +9,13 @@ using DocumenterTools: Themes
 ENV["JULIA_DEBUG"] = "Documenter"
 
 # For easier debugging when downloading from a specific branch.
-github_user = "kahaaga"
-branch = "documenter_v1"
+github_user = "JuliaDynamics"
+branch = "master"
+download_path = "https://raw.githubusercontent.com/$github_user/doctheme/$branch"
 
 import Downloads
 for file in ("juliadynamics-lightdefs.scss", "juliadynamics-darkdefs.scss", "juliadynamics-style.scss")
-    Downloads.download("https://raw.githubusercontent.com/$github_user/doctheme/$branch/$file", joinpath(@__DIR__, file))
+    Downloads.download("$download_path/$file", joinpath(@__DIR__, file))
 end
 
 # create the themes
@@ -30,7 +31,7 @@ Themes.compile(joinpath(@__DIR__, "juliadynamics-dark.scss"), joinpath(@__DIR__,
 
 # Download and apply CairoMakie plotting style
 using CairoMakie
-Downloads.download("https://raw.githubusercontent.com/$github_user/doctheme/$branch/style.jl", joinpath(@__DIR__, "style.jl"))
+Downloads.download("$download_path/style.jl", joinpath(@__DIR__, "style.jl"))
 include("style.jl")
 
 function build_docs_with_style(pages, modules...; bib = nothing, authors = "George Datseris", draft = false, kwargs...)

--- a/build_docs_with_style.jl
+++ b/build_docs_with_style.jl
@@ -48,6 +48,7 @@ function build_docs_with_style(pages, modules...; bib = nothing, authors = "Geor
         pages,
         draft,
         doctest = false,
+        checkdocs = :exported,
         kwargs...
     )
 

--- a/build_docs_with_style.jl
+++ b/build_docs_with_style.jl
@@ -10,7 +10,7 @@ ENV["JULIA_DEBUG"] = "Documenter"
 # download the themes
 import Downloads
 for file in ("juliadynamics-lightdefs.scss", "juliadynamics-darkdefs.scss", "juliadynamics-style.scss")
-    Downloads.download("https://raw.githubusercontent.com/JuliaDynamics/doctheme/master/$file", joinpath(@__DIR__, file))
+    Downloads.download("https://raw.githubusercontent.com/kahaaga/doctheme/master/$file", joinpath(@__DIR__, file))
 end
 # create the themes
 for w in ("light", "dark")
@@ -23,7 +23,7 @@ Themes.compile(joinpath(@__DIR__, "juliadynamics-light.scss"), joinpath(@__DIR__
 Themes.compile(joinpath(@__DIR__, "juliadynamics-dark.scss"), joinpath(@__DIR__, "src/assets/themes/documenter-dark.css"))
 # Download and apply CairoMakie plotting style
 using CairoMakie
-Downloads.download("https://raw.githubusercontent.com/JuliaDynamics/doctheme/master/style.jl", joinpath(@__DIR__, "style.jl"))
+Downloads.download("https://raw.githubusercontent.com/kahaaga/doctheme/master/style.jl", joinpath(@__DIR__, "style.jl"))
 include("style.jl")
 
 function build_docs_with_style(pages, modules...; bib = nothing, authors = "George Datseris", draft = false, kwargs...)

--- a/build_docs_with_style.jl
+++ b/build_docs_with_style.jl
@@ -1,29 +1,36 @@
 CI = get(ENV, "CI", nothing) == "true" || get(ENV, "GITHUB_TOKEN", nothing) !== nothing
 
 import Pkg
-Pkg.pkg"add Documenter@1.2"
+Pkg.pkg"add Documenter@1"
 
 # Load documenter
 using Documenter
 using DocumenterTools: Themes
 ENV["JULIA_DEBUG"] = "Documenter"
-# download the themes
+
+# For easier debugging when downloading from a specific branch.
+github_user = "kahaaga"
+branch = "documenter_v1"
+
 import Downloads
 for file in ("juliadynamics-lightdefs.scss", "juliadynamics-darkdefs.scss", "juliadynamics-style.scss")
-    Downloads.download("https://raw.githubusercontent.com/kahaaga/doctheme/master/$file", joinpath(@__DIR__, file))
+    Downloads.download("https://raw.githubusercontent.com/$github_user/doctheme/$branch/$file", joinpath(@__DIR__, file))
 end
+
 # create the themes
 for w in ("light", "dark")
     header = read(joinpath(@__DIR__, "juliadynamics-style.scss"), String)
     theme = read(joinpath(@__DIR__, "juliadynamics-$(w)defs.scss"), String)
     write(joinpath(@__DIR__, "juliadynamics-$(w).scss"), header*"\n"*theme)
 end
+
 # compile the themes
 Themes.compile(joinpath(@__DIR__, "juliadynamics-light.scss"), joinpath(@__DIR__, "src/assets/themes/documenter-light.css"))
 Themes.compile(joinpath(@__DIR__, "juliadynamics-dark.scss"), joinpath(@__DIR__, "src/assets/themes/documenter-dark.css"))
+
 # Download and apply CairoMakie plotting style
 using CairoMakie
-Downloads.download("https://raw.githubusercontent.com/kahaaga/doctheme/master/style.jl", joinpath(@__DIR__, "style.jl"))
+Downloads.download("https://raw.githubusercontent.com/$github_user/doctheme/$branch/style.jl", joinpath(@__DIR__, "style.jl"))
 include("style.jl")
 
 function build_docs_with_style(pages, modules...; bib = nothing, authors = "George Datseris", draft = false, kwargs...)

--- a/juliadynamics-darkdefs.scss
+++ b/juliadynamics-darkdefs.scss
@@ -40,6 +40,8 @@ $input-focus-border-color: $mainwhite;
 
 $documenter-docstring-shadow: 3px 3px 4px invert($shadow-color);
 
+
+
 // Admonition stuff
 $admbg: lighten-color($body-background-color, 0.5);
 $admonition-background: (
@@ -49,6 +51,10 @@ $admonition-background: (
 $admonition-header-background: (
   'default': #ba3f1f, 'warning': #a88b17, 'danger': #c7524c,
   'success': #42ac68, 'info': #28c);
+
+// Deprecations
+$admonition-body-color: null;
+$admonition-header-color: null;
 
 // All secondary themes have to be nested in a theme--$(themename) class. When Documenter
 // switches themes, it applies this class to <html> and then disables the primary

--- a/juliadynamics-darkdefs.scss
+++ b/juliadynamics-darkdefs.scss
@@ -59,7 +59,7 @@ $admonition-header-background: (
 @import "documenter/variables";
 @import "bulma/utilities/all";
 @import "bulma/base/minireset.sass";
-@import "bulma/base/helpers.sass";
+@import "sass/helpers/_all";
 
 html.theme--#{$themename} {
   @import "bulma/base/generic.sass";

--- a/juliadynamics-darkdefs.scss
+++ b/juliadynamics-darkdefs.scss
@@ -52,10 +52,6 @@ $admonition-header-background: (
   'default': #ba3f1f, 'warning': #a88b17, 'danger': #c7524c,
   'success': #42ac68, 'info': #28c);
 
-// Deprecations
-$admonition-body-color: null;
-$admonition-header-color: null;
-
 // All secondary themes have to be nested in a theme--$(themename) class. When Documenter
 // switches themes, it applies this class to <html> and then disables the primary
 // stylesheet.

--- a/juliadynamics-darkdefs.scss
+++ b/juliadynamics-darkdefs.scss
@@ -68,7 +68,7 @@ $admonition-header-color: null;
 
 html.theme--#{$themename} {
   @extend .is-size-7 !optional;
-  
+
   @import "bulma/base/generic.sass";
 
   @import "documenter/overrides";
@@ -89,10 +89,7 @@ html.theme--#{$themename} {
   @import "documenter/theme_overrides";
 
   // $shadow-color: #202224;
-  @warn 'This is a warning';
-
-  @extend .is-size-7;
-
+  
   #documenter .docs-sidebar { // This makes sidebar have shadow at all displays
     border-right: none;
     box-shadow: 1.2*$shadow-size 0rem 1*$shadow-blur invert($shadow-color);

--- a/juliadynamics-darkdefs.scss
+++ b/juliadynamics-darkdefs.scss
@@ -52,6 +52,11 @@ $admonition-header-background: (
   'default': #ba3f1f, 'warning': #a88b17, 'danger': #c7524c,
   'success': #42ac68, 'info': #28c);
 
+// Deprecations
+$admonition-body-color: null;
+$admonition-body-color: null;
+$admonition-header-color: null;
+
 // All secondary themes have to be nested in a theme--$(themename) class. When Documenter
 // switches themes, it applies this class to <html> and then disables the primary
 // stylesheet.

--- a/juliadynamics-darkdefs.scss
+++ b/juliadynamics-darkdefs.scss
@@ -87,6 +87,9 @@ html.theme--#{$themename} {
   @import "documenter/theme_overrides";
 
   // $shadow-color: #202224;
+  @warn 'This is a warning';
+
+  @extend .is-size-7;
 
   #documenter .docs-sidebar { // This makes sidebar have shadow at all displays
     border-right: none;

--- a/juliadynamics-darkdefs.scss
+++ b/juliadynamics-darkdefs.scss
@@ -64,9 +64,11 @@ $admonition-header-color: null;
 @import "documenter/variables";
 @import "bulma/utilities/all";
 @import "bulma/base/minireset.sass";
-@import "bulma/sass/helpers/_all.sass";
+@import "bulma/helpers/_all.sass";
 
 html.theme--#{$themename} {
+  @extend .is-size-7 !optional;
+  
   @import "bulma/base/generic.sass";
 
   @import "documenter/overrides";

--- a/juliadynamics-darkdefs.scss
+++ b/juliadynamics-darkdefs.scss
@@ -64,7 +64,7 @@ $admonition-header-color: null;
 @import "documenter/variables";
 @import "bulma/utilities/all";
 @import "bulma/base/minireset.sass";
-@import "bulma/sass/helpers/_all";
+@import "bulma/sass/helpers/_all.sass";
 
 html.theme--#{$themename} {
   @import "bulma/base/generic.sass";

--- a/juliadynamics-darkdefs.scss
+++ b/juliadynamics-darkdefs.scss
@@ -59,7 +59,7 @@ $admonition-header-background: (
 @import "documenter/variables";
 @import "bulma/utilities/all";
 @import "bulma/base/minireset.sass";
-@import "sass/helpers/_all";
+@import "bulma/sass/helpers/_all";
 
 html.theme--#{$themename} {
   @import "bulma/base/generic.sass";

--- a/juliadynamics-lightdefs.scss
+++ b/juliadynamics-lightdefs.scss
@@ -46,10 +46,6 @@ $documenter-sidebar-size: 1.0em; // the default is 1.0 as well
 $input-hover-border-color: $secondcolor;
 $input-focus-border-color: $mainwhite;
 
-// Include the original theme which will now use the updated variables.
-// This should be the last thing in the SCSS file.
-@import "documenter-light";
-
 #documenter .docs-sidebar { // This makes sidebar have shadow at all displays
   border-right: none;
   box-shadow: 1.2*$shadow-size 0rem 1*$shadow-blur $shadow-color;
@@ -65,3 +61,7 @@ $input-focus-border-color: $mainwhite;
     }
   }
 }
+
+// Include the original theme which will now use the updated variables.
+// This should be the last thing in the SCSS file.
+@import "documenter-light";

--- a/juliadynamics-lightdefs.scss
+++ b/juliadynamics-lightdefs.scss
@@ -46,10 +46,6 @@ $documenter-sidebar-size: 1.0em; // the default is 1.0 as well
 $input-hover-border-color: $secondcolor;
 $input-focus-border-color: $mainwhite;
 
-// Deprecations
-$admonition-body-color: null;
-$admonition-header-color: null;
-
 // Include the original theme which will now use the updated variables.
 // This should be the last thing in the SCSS file.
 @import "documenter-light";

--- a/juliadynamics-lightdefs.scss
+++ b/juliadynamics-lightdefs.scss
@@ -46,6 +46,10 @@ $documenter-sidebar-size: 1.0em; // the default is 1.0 as well
 $input-hover-border-color: $secondcolor;
 $input-focus-border-color: $mainwhite;
 
+// Deprecations
+$admonition-body-color: null;
+$admonition-header-color: null;
+
 // Include the original theme which will now use the updated variables.
 // This should be the last thing in the SCSS file.
 @import "documenter-light";

--- a/juliadynamics-style.scss
+++ b/juliadynamics-style.scss
@@ -4,6 +4,12 @@
 // under documenter/_variables or documenter/_overrides. But some stuff are Bulma defaults
 // as well, so you may need to look them up too: https://bulma.io/documentation/customize/variables/
 
+// Deprecations
+$admonition-body-color: null;
+// Deprecations
+$admonition-body-color: null;
+$admonition-header-color: null;
+@extend .is-size-7 !optional;
 
 ////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////

--- a/juliadynamics-style.scss
+++ b/juliadynamics-style.scss
@@ -6,9 +6,10 @@
 
 // Deprecations
 $admonition-body-color: null;
-// Deprecations
 $admonition-body-color: null;
 $admonition-header-color: null;
+
+@import "sass/helpers/all";
 @extend .is-size-7 !optional;
 
 ////////////////////////////////////////////////////////////////////////

--- a/juliadynamics-style.scss
+++ b/juliadynamics-style.scss
@@ -4,11 +4,6 @@
 // under documenter/_variables or documenter/_overrides. But some stuff are Bulma defaults
 // as well, so you may need to look them up too: https://bulma.io/documentation/customize/variables/
 
-// Deprecations
-$admonition-body-color: null;
-$admonition-body-color: null;
-$admonition-header-color: null;
-
 ////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////
 // Thse define the JuliaDynamics template:

--- a/juliadynamics-style.scss
+++ b/juliadynamics-style.scss
@@ -9,9 +9,6 @@ $admonition-body-color: null;
 $admonition-body-color: null;
 $admonition-header-color: null;
 
-@import "sass/helpers/all";
-@extend .is-size-7 !optional;
-
 ////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////
 // Thse define the JuliaDynamics template:


### PR DESCRIPTION
Fixes points 1-3 in #2.

# Changes

- Construct the download path from github username and branch name instead of hardcoding. I spent quite some time debugging errors that turned out to be due to erroneous download paths when forking. We can revert to absolute paths if necessary, but this change will make it a bit easier for anyone in the future that makes changes to get it right.
- bulma helper files were moved to another folder in v1. The relevant import path has been modified accordingly.
- A few lines to take care of deprecations.
- Moved code block that in the comments said needed to be last in the file to actually be last in the file.

