### PR TITLE
Update juliadynamics-darkdefs.scss

### DIFF
--- a/juliadynamics-darkdefs.scss
+++ b/juliadynamics-darkdefs.scss
@@ -109,65 +109,23 @@ html.theme--#{$themename} {
     color: #f8f8f2;
   }
 
+  $admonition-colors: (
+  'default', 'info', 'success', 'warning',
+  'danger','compat',
+) !default;
   // extend this to all types
   .admonition {
-    &.is-warning {
-      > .admonition-body {
-        color:#fff;
-      }
-      > .admonition-header {
-        color:#fff;
-      }
-    }
-    &.is-default {
-      > .admonition-body {
-        color:#fff;
-      }
-      > .admonition-header {
-        color:#fff;
+    @each $name, $pair in $admonition-colors {
+      &.is-#{$name} {
+        > .admonition-body {
+          color:#fff;
+        }
+        > .admonition-header {
+          color:#fff;
+        }
       }
     }
-    &.is-body {
-      > .admonition-body {
-        color:#fff;
-      }
-      > .admonition-header {
-        color:#fff;
-      }
-    }
-    &.is-info {
-      > .admonition-body {
-        color:#fff;
-      }
-      > .admonition-header {
-        color:#fff;
-      }
-    }
-    &.is-success {
-      > .admonition-body {
-        color:#fff;
-      }
-      > .admonition-header {
-        color:#fff;
-      }
-    }  
-    &.is-danger {
-      > .admonition-body {
-        color:#fff;
-      }
-      > .admonition-header {
-        color:#fff;
-      }
-    }
-    &.is-compat {
-      > .admonition-body {
-        color:#fff;
-      }
-      > .admonition-header {
-        color:#fff;
-      }
-    }  
-
+  
 }
 }
 

--- a/juliadynamics-darkdefs.scss
+++ b/juliadynamics-darkdefs.scss
@@ -53,9 +53,6 @@ $admonition-header-background: (
   'success': #42ac68, 'info': #28c);
 
 // Deprecations
-$admonition-body-color: null;
-$admonition-body-color: null;
-$admonition-header-color: null;
 
 // All secondary themes have to be nested in a theme--$(themename) class. When Documenter
 // switches themes, it applies this class to <html> and then disables the primary
@@ -111,4 +108,67 @@ html.theme--#{$themename} {
   .hljs-subst {
     color: #f8f8f2;
   }
+
+  // extend this to all types
+  .admonition {
+    &.is-warning {
+      > .admonition-body {
+        color:#fff;
+      }
+      > .admonition-header {
+        color:#fff;
+      }
+    }
+    &.is-default {
+      > .admonition-body {
+        color:#fff;
+      }
+      > .admonition-header {
+        color:#fff;
+      }
+    }
+    &.is-body {
+      > .admonition-body {
+        color:#fff;
+      }
+      > .admonition-header {
+        color:#fff;
+      }
+    }
+    &.is-info {
+      > .admonition-body {
+        color:#fff;
+      }
+      > .admonition-header {
+        color:#fff;
+      }
+    }
+    &.is-success {
+      > .admonition-body {
+        color:#fff;
+      }
+      > .admonition-header {
+        color:#fff;
+      }
+    }  
+    &.is-danger {
+      > .admonition-body {
+        color:#fff;
+      }
+      > .admonition-header {
+        color:#fff;
+      }
+    }
+    &.is-compat {
+      > .admonition-body {
+        color:#fff;
+      }
+      > .admonition-header {
+        color:#fff;
+      }
+    }  
+
 }
+}
+
+


### PR DESCRIPTION
Update juliadynamics-darkdefs.scss

- force the admonition to be dark for dark backgrounds

Inspired from the code at https://github.com/JuliaDocs/Documenter.jl/blob/master/assets/html/scss/documenter/components/_admonition.scss

Fixes the dark theme issue where admonition text stay dark
<img width="859" alt="image" src="https://github.com/JuliaDynamics/doctheme/assets/115779707/81cf875a-ec95-4f08-9bd2-bf07076151d2">

And where the `css` for that element is pure black (or close to it)
```css
html.theme--documenter-dark .admonition.is-info>.admonition-body {
  color:rgba(0,0,0,0.7)
}
```
