### PR TITLE
Update juliadynamics-darkdefs.scss

### DIFF
--- a/juliadynamics-darkdefs.scss
+++ b/juliadynamics-darkdefs.scss
@@ -24,6 +24,7 @@ $code-background: $codebg; // for inline code
 $pre-background: $codebg;  // for code blocks
 $documenter-docstring-header-background: lighten-color($body-background-color, 0.5);
 
+
 // Sidebar
 $documenter-sidebar-background: darken-color($maincolor, 1.2); //background color for sidebar
 $documenter-sidebar-color: $text; //font color for sidebar
@@ -51,8 +52,6 @@ $admonition-background: (
 $admonition-header-background: (
   'default': #ba3f1f, 'warning': #a88b17, 'danger': #c7524c,
   'success': #42ac68, 'info': #28c);
-
-// Deprecations
 
 // All secondary themes have to be nested in a theme--$(themename) class. When Documenter
 // switches themes, it applies this class to <html> and then disables the primary
@@ -109,6 +108,7 @@ html.theme--#{$themename} {
     color: #f8f8f2;
   }
 
+
   $admonition-colors: (
   'default', 'info', 'success', 'warning',
   'danger','compat',
@@ -125,8 +125,35 @@ html.theme--#{$themename} {
         }
       }
     }
-  
-}
-}
+  }
 
+  // fix for the settings/modal panel
+  .modal-card-head {
+    background-color: darken($darkbg,5);
+  }
+  .modal-card-body {
+    background-color: darken($darkbg,5);
+  }
+  .modal-card-foot {
+    background-color: darken($darkbg,5);
+  }
+  .select {
+    > select {
+    background-color: darken($darkbg,5); 
+    }
+  } 
 
+  // fix for the search panel
+  .input {
+    background-color: darken($darkbg,5);
+  }
+  .search-result-title {
+    color: white
+  }
+
+  // match the size of the light theme (additional rule 
+  // that is dark-theme specific and messing around 
+  // with the size of elements, making the size be 0,75em
+  // only for the dark theme, no idea why)
+  font-size: unset !important;
+}


### PR DESCRIPTION
- fixes #4 :  dark theme having a different font size from the light theme 
- fix for search bar/theme switcher/version selector in dark mode
Before/after: 
<img width="40%" alt="image" src="https://github.com/JuliaDynamics/doctheme/assets/115779707/e5959cd4-fc9a-4b82-a103-b41e27043dba">
<img width="40%" alt="image" src="https://github.com/JuliaDynamics/doctheme/assets/115779707/1e01f343-9402-4d00-88c2-654385a980a4">

<img width="40%" alt="image" src="https://github.com/JuliaDynamics/doctheme/assets/115779707/9b5ffbeb-22c4-4d2c-b720-331df80a531f">
<img width="40%" alt="image" src="https://github.com/JuliaDynamics/doctheme/assets/115779707/746f082e-f429-4957-9e15-c138378629a8">